### PR TITLE
Set Automatic-Module-Name in manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ ihmc {
    configurePublications()
 }
 
+tasks.jar {
+   manifest {
+      attributes("Automatic-Module-Name" to "us.ihmc.nativelibraryloader")
+   }
+}
+
 mainDependencies {
    api("org.apache.commons:commons-lang3:3.12.0")
 }


### PR DESCRIPTION
Avoids issue with 'native' keyword in generated module name

e.g.
```
$ jar --describe-module --file=ihmc-native-library-loader-2.0.3.jar 
Unable to derive module descriptor for: ihmc-native-library-loader-2.0.3.jar
ihmc.native.library.loader: Invalid module name: 'native' is not a Java identifier
```